### PR TITLE
feat: add --force flag to allow DELETE without WHERE clause

### DIFF
--- a/include/parser.h
+++ b/include/parser.h
@@ -4,6 +4,9 @@
 #include <stdbool.h>
 #include "tokenizer.h"
 
+/* global flag to allow DELETE without WHERE clause */
+extern bool force_delete;
+
 
 typedef enum {
     NODE_TYPE_QUERY,

--- a/src/main.c
+++ b/src/main.c
@@ -21,9 +21,17 @@ int main(int argc, char* argv[]) {
     char input_separator = ',';
     char output_delimiter = ',';
     
+    // long options for --force
+    static struct option long_options[] = {
+        {"force", no_argument, 0, 'F'},
+        {"help", no_argument, 0, 'h'},
+        {0, 0, 0, 0}
+    };
+    
     // parse args
     int opt;
-    while ((opt = getopt(argc, argv, "hq:f:o:cps:d:v")) != -1) {
+    int option_index = 0;
+    while ((opt = getopt_long(argc, argv, "hq:f:o:cps:d:vF", long_options, &option_index)) != -1) {
         switch (opt) {
             case 'h':
                 print_help(argv[0]);
@@ -52,6 +60,9 @@ int main(int argc, char* argv[]) {
             case 'v':
                 vertical_output = true;
                 print_table = true;  // implicit
+                break;
+            case 'F':
+                force_delete = true;
                 break;
             default:
                 print_help(argv[0]);

--- a/src/parser.c
+++ b/src/parser.c
@@ -7,9 +7,6 @@
 #include <ctype.h>
 #include "parser.h"
 #include "tokenizer.h"
-
-/* global flag to allow DELETE without WHERE clause */
-bool force_delete = false;
 #include "string_utils.h"
 #include "parser/parser_core.h"
 #include "parser/ast_nodes.h"
@@ -17,6 +14,9 @@ bool force_delete = false;
 #include "parser/parser_clauses.h"
 #include "parser/parser_statements.h"
 #include "parser/parser_internal.h"
+
+/* global flag to allow DELETE/UPDATE without WHERE clause */
+bool force_delete = false;
 
 // forward declarations for functions defined in submodules
 ASTNode* parse_select(Parser* parser);

--- a/src/parser.c
+++ b/src/parser.c
@@ -7,6 +7,9 @@
 #include <ctype.h>
 #include "parser.h"
 #include "tokenizer.h"
+
+/* global flag to allow DELETE without WHERE clause */
+bool force_delete = false;
 #include "string_utils.h"
 #include "parser/parser_core.h"
 #include "parser/ast_nodes.h"

--- a/src/parser/parser_statements.c
+++ b/src/parser/parser_statements.c
@@ -229,10 +229,11 @@ ASTNode* parse_delete(Parser* parser) {
     node->delete_stmt.where = NULL;
     parser_advance(parser);
     
-    // WHERE, required for safety, we don't allow DELETE without WHERE
+    // WHERE, required for safety unless --force flag is set
     node->delete_stmt.where = parse_where(parser);
-    if (!node->delete_stmt.where) {
+    if (!node->delete_stmt.where && !force_delete) {
         fprintf(stderr, "Error: WHERE clause is required for DELETE (safety measure)\n");
+        fprintf(stderr, "       Use --force flag to allow DELETE without WHERE\n");
         releaseNode(node);
         return NULL;
     }

--- a/src/utils.c
+++ b/src/utils.c
@@ -97,7 +97,7 @@ char* skipWhitespaces(char* str) {
 void print_help(const char* program_name) {
     printf("Usage: %s [OPTIONS]\n", program_name);
     printf("\nOptions:\n");
-    printf("  -h           Show this help message\n");
+    printf("  -h, --help   Show this help message\n");
     printf("  -q <query>   SQL query to execute (use '-' to read from stdin)\n");
     printf("  -f <file>    Read SQL query from file\n");
     printf("  -o <file>    Write result as CSV to output file\n");
@@ -106,6 +106,7 @@ void print_help(const char* program_name) {
     printf("  -v           Print result in vertical format (one column per line)\n");
     printf("  -s <char>    Field separator for input CSV (default: ',')\n");
     printf("  -d <char>    Output delimiter for -o option (default: ',')\n");
+    printf("  -F, --force  Allow DELETE without WHERE clause (dangerous!)\n");
     printf("\nExamples:\n");
     printf("  %s -q \"SELECT name, age WHERE age > 30\" -p\n", program_name);
     printf("  %s -f query.sql -p\n", program_name);

--- a/tests/test_force_flag.c
+++ b/tests/test_force_flag.c
@@ -1,0 +1,108 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include "test_framework.h"
+#include "parser.h"
+#include "evaluator.h"
+#include "csv_reader.h"
+
+/* external force flag defined in parser.c */
+extern bool force_delete;
+
+/* helper function to create a temporary test file */
+static void create_test_file(const char* filename, const char* content) {
+    FILE* f = fopen(filename, "w");
+    if (f) {
+        fprintf(f, "%s", content);
+        fclose(f);
+    }
+}
+
+/* test DELETE without WHERE fails without force flag */
+void test_delete_without_where_fails() {
+    TEST_START("DELETE without WHERE fails without force flag");
+    
+    force_delete = false;
+    
+    ASTNode* ast = parse("DELETE FROM 'data/test.csv'");
+    ASSERT_NULL(ast);
+    
+    TEST_PASS();
+}
+
+/* test DELETE without WHERE succeeds with force flag */
+void test_delete_without_where_with_force() {
+    TEST_START("DELETE without WHERE succeeds with force flag");
+    
+    const char* test_file = "data/test_force_delete.csv";
+    create_test_file(test_file, "id,name,age\n1,Alice,25\n2,Bob,30\n3,Charlie,35\n");
+    
+    force_delete = true;
+    
+    ASTNode* ast = parse("DELETE FROM 'data/test_force_delete.csv'");
+    ASSERT_NOT_NULL(ast);
+    
+    ResultSet* result = evaluate_query(ast);
+    ASSERT_NOT_NULL(result);
+    
+    releaseNode(ast);
+    csv_free(result);
+    
+    /* verify all rows were deleted */
+    CsvConfig config = csv_config_default();
+    CsvTable* table = csv_load(test_file, config);
+    ASSERT_NOT_NULL(table);
+    ASSERT_EQUAL(0, table->row_count);
+    
+    csv_free(table);
+    unlink(test_file);
+    
+    force_delete = false;  /* reset */
+    
+    TEST_PASS();
+}
+
+/* test DELETE with WHERE works regardless of force flag */
+void test_delete_with_where_always_works() {
+    TEST_START("DELETE with WHERE works regardless of force flag");
+    
+    const char* test_file = "data/test_delete_where.csv";
+    create_test_file(test_file, "id,name,age\n1,Alice,25\n2,Bob,30\n3,Charlie,35\n");
+    
+    force_delete = false;
+    
+    ASTNode* ast = parse("DELETE FROM 'data/test_delete_where.csv' WHERE age > 30");
+    ASSERT_NOT_NULL(ast);
+    
+    ResultSet* result = evaluate_query(ast);
+    ASSERT_NOT_NULL(result);
+    
+    releaseNode(ast);
+    csv_free(result);
+    
+    /* verify only one row was deleted */
+    CsvConfig config = csv_config_default();
+    CsvTable* table = csv_load(test_file, config);
+    ASSERT_NOT_NULL(table);
+    ASSERT_EQUAL(2, table->row_count);
+    
+    csv_free(table);
+    unlink(test_file);
+    
+    TEST_PASS();
+}
+
+int main() {
+    printf("\n=== Running Force Flag Tests ===\n\n");
+    
+    /* DELETE tests */
+    test_delete_without_where_fails();
+    test_delete_without_where_with_force();
+    test_delete_with_where_always_works();
+    
+    print_test_summary();
+    
+    return tests_failed > 0 ? 1 : 0;
+}


### PR DESCRIPTION
Closes: https://github.com/baldimario/cq/issues/4

This pull request adds a new safety override for SQL DELETE statements, allowing users to bypass the required WHERE clause restriction by using a new `--force` flag. The implementation introduces a global flag to control this behavior, updates the command-line interface to support the new option, and improves the help documentation accordingly.

**New safety override for DELETE statements:**

* Introduced a global `force_delete` flag in `parser.h` and defined it in `parser.c` to control whether DELETE statements are allowed without a WHERE clause. [[1]](diffhunk://#diff-3b2df7c1bd222e92cf09a90765c2c75bf7353069fd6ff0ea90b4d5a280d0823bR7-R9) [[2]](diffhunk://#diff-3045e316fef9708ebd7095e9a191c711c5dd24e58cdb91c0961961463fabacccR10-R12)
* Modified the `parse_delete` logic in `parser_statements.c` to allow DELETE without a WHERE clause only if the `force_delete` flag is set, and updated the error message to inform users about the `--force` flag.

**Command-line interface updates:**

* Added a new `-F`/`--force` command-line option in `main.c` to set the `force_delete` flag, using `getopt_long` to support long options. [[1]](diffhunk://#diff-e0cf5b28d9b6b600f0af2bc78e8fd30ec675fd731a5da86f0c4283ffc0e40176R24-R34) [[2]](diffhunk://#diff-e0cf5b28d9b6b600f0af2bc78e8fd30ec675fd731a5da86f0c4283ffc0e40176R64-R66)

**Help and documentation improvements:**

* Updated the help output in `utils.c` to document the new `-F`/`--force` option and clarified the help for `-h`/`--help`. [[1]](diffhunk://#diff-3e04e056edbdc0f772b0ffd1c93cef1187209f37276d40d2a281d9b989398a73L100-R100) [[2]](diffhunk://#diff-3e04e056edbdc0f772b0ffd1c93cef1187209f37276d40d2a281d9b989398a73R109)