### PR TITLE
fix: apply quoting logic to header names in csv output

### DIFF
--- a/src/utils.c
+++ b/src/utils.c
@@ -218,6 +218,35 @@ char* read_query_from_stdin(void) {
     return query;
 }
 
+/* write a conditionally quoted string to file */
+static void write_quoted_str(FILE* f, const char* str, const char delimiter) {
+    // check if string contains delimiter, newline, or quote char
+    bool needs_quoting = false;
+    if (str) {
+        for (const char* p = str; *p; p++) {
+            if (*p == delimiter || *p == '"' || *p == '\n' || *p == '\r') {
+                needs_quoting = true;
+                break;
+            }
+        }
+    }
+    
+    if (needs_quoting) {
+        fprintf(f, "\"");
+        // escape quotes by doubling them
+        for (const char* p = str; *p; p++) {
+            if (*p == '"') {
+                fprintf(f, "\"\"");
+            } else {
+                fprintf(f, "%c", *p);
+            }
+        }
+        fprintf(f, "\"");
+    } else {
+        fprintf(f, "%s", str ? str : "");
+    }
+}
+
 /* wsrite ResultSet to CSV file */
 void write_csv_file(const char* filename, ResultSet* result, char delimiter) {
     FILE* f = fopen(filename, "w");
@@ -229,7 +258,7 @@ void write_csv_file(const char* filename, ResultSet* result, char delimiter) {
     // header
     for (int i = 0; i < result->column_count; i++) {
         if (i > 0) fprintf(f, "%c", delimiter);
-        fprintf(f, "%s", result->columns[i].name);
+        write_quoted_str(f, result->columns[i].name, delimiter);
     }
     fprintf(f, "\n");
     
@@ -255,34 +284,9 @@ void write_csv_file(const char* filename, ResultSet* result, char delimiter) {
                             val->date_value.month,
                             val->date_value.day);
                     break;
-                case VALUE_TYPE_STRING: {
-                    // check if string contains delimiter, newline, or quote char
-                    bool needs_quoting = false;
-                    if (val->string_value) {
-                        for (const char* p = val->string_value; *p; p++) {
-                            if (*p == delimiter || *p == '"' || *p == '\n' || *p == '\r') {
-                                needs_quoting = true;
-                                break;
-                            }
-                        }
-                    }
-                    
-                    if (needs_quoting) {
-                        fprintf(f, "\"");
-                        // escape quotes by doubling them
-                        for (const char* p = val->string_value; *p; p++) {
-                            if (*p == '"') {
-                                fprintf(f, "\"\"");
-                            } else {
-                                fprintf(f, "%c", *p);
-                            }
-                        }
-                        fprintf(f, "\"");
-                    } else {
-                        fprintf(f, "%s", val->string_value ? val->string_value : "");
-                    }
+                case VALUE_TYPE_STRING:
+                    write_quoted_str(f, val->string_value, delimiter);
                     break;
-                }
             }
         }
         fprintf(f, "\n");


### PR DESCRIPTION
Addresses #7.

I basically took the quoting logic from `utils.c`:

https://github.com/baldimario/cq/blob/19abc55e172144997d9f5991bfa90bd67ce10fd1/src/utils.c#L259-L284

I separated this logic into a function called `write_quoted_str`, then applied it to the column headers:

<img width="627" height="142" alt="image" src="https://github.com/user-attachments/assets/ff04fb6c-2d41-4c16-98e2-cd4775accdc4" />

With this change, `cq -q "SELECT * from file.csv" -o output.csv` produces these results:

`file.csv`
```
Obj1Key,"Obj2Key1,Obj2Key2",Obj3"Key"
"ObjA2","ObjB2",Obj"C"2
ObjA3,"ObjB23ObjB3",Obj"C"3
"ObjA4","ObjB4,ObjB4",Obj"C"4
```

`output.csv`
```
Obj1Key,"Obj2Key1,Obj2Key2","Obj3""Key"""
ObjA2,ObjB2,"Obj""C""2"
ObjA3,ObjB23ObjB3,"Obj""C""3"
ObjA4,"ObjB4,ObjB4","Obj""C""4"
```

Note how the second column header name, `Obj2Key1,Obj2Key2` is properly quoted in the output. 😄 

A side effect is that `Obj3"Key"` is now quoted as `"Obj3""Key"""`, following the double-quoting guidelines.

If this needs a separate test, let me know. 👍🏻 